### PR TITLE
Adds a TGUI confirmation warning to the bottle of mayhem

### DIFF
--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -254,7 +254,7 @@
 		|| QDELETED(parent) \
 		|| QDELETED(real_location) \
 		|| QDELETED(user) \
-		|| !user.can_perform_action(parent, NEED_DEXTERITY) 
+		|| !user.can_perform_action(parent, NEED_DEXTERITY) \
 	)
 		return
 	for(var/mob/living/carbon/human/target in range(7,user))

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -249,6 +249,14 @@
 	icon_state = "vial"
 
 /obj/item/mayhem/attack_self(mob/user)
+        var/safety = tgui_alert(user, "Doing this will drive nearby crewmembers into a murderous frenzy. Be sure you know what you're doing.", "Break the bottle?", list("Proceed", "Abort"))
+	if(safety != "Proceed" \
+		|| QDELETED(parent) \
+		|| QDELETED(real_location) \
+		|| QDELETED(user) \
+		|| !user.can_perform_action(parent, NEED_DEXTERITY) 
+	)
+		return
 	for(var/mob/living/carbon/human/target in range(7,user))
 		target.apply_status_effect(/datum/status_effect/mayhem)
 	to_chat(user, span_notice("You shatter the bottle!"))


### PR DESCRIPTION

## About The Pull Request

Adds a TGUI warning for the bottle of mayhem if you try to break it so that you know what you are about to do 
## Why It's Good For The Game

Having a confirmation warning allows the player to know what the mayhem in a bottle will do (drives people into a killing frenzy) and give them one more chance before actually breaking the bottle, especially for nonantags who may not know what it actually does.
## Changelog
:cl:
qol: Alerts the player to the effect of the mayhem in a bottle's effect 
/:cl:
